### PR TITLE
- Fix Java Rectangle function to Rectangle2D to work with modern Java

### DIFF
--- a/src/main/java/net/freerouting/freeroute/BoardFrame.java
+++ b/src/main/java/net/freerouting/freeroute/BoardFrame.java
@@ -39,6 +39,7 @@ import net.freerouting.freeroute.datastructures.IdNoGenerator;
 import net.freerouting.freeroute.designformats.specctra.DsnFileException;
 import net.freerouting.freeroute.interactive.BoardHandlingException;
 import net.freerouting.freeroute.interactive.ScreenMessages;
+import java.awt.geom.Rectangle2D;
 
 /**
  *
@@ -261,14 +262,14 @@ public class BoardFrame extends javax.swing.JFrame {
                     });
                 }
                 java.awt.Point frame_location;
-                java.awt.Rectangle frame_bounds;
+                Rectangle2D frame_bounds;
                 try {
                     viewport_position = (java.awt.Point) object_stream.readObject();
                     frame_location = (java.awt.Point) object_stream.readObject();
-                    frame_bounds = (java.awt.Rectangle) object_stream.readObject();
+                    frame_bounds = (Rectangle2D) object_stream.readObject();
 
                     setLocation(frame_location);
-                    setBounds(frame_bounds);
+                    setBounds(frame_bounds.getBounds());
 
                     allocate_permanent_subwindows();
 
@@ -429,8 +430,8 @@ public class BoardFrame extends javax.swing.JFrame {
      */
     public void zoom_all() {
         board_panel.board_handling.adjust_design_bounds();
-        java.awt.Rectangle display_rect = board_panel.get_viewport_bounds();
-        java.awt.Rectangle design_bounds = board_panel.board_handling.graphics_context.get_design_bounds();
+        Rectangle2D display_rect = board_panel.get_viewport_bounds().getBounds();
+        Rectangle2D design_bounds = board_panel.board_handling.graphics_context.get_design_bounds().getBounds();
         double width_factor = display_rect.getWidth() / design_bounds.getWidth();
         double height_factor = display_rect.getHeight() / design_bounds.getHeight();
         double zoom_factor = Math.min(width_factor, height_factor);

--- a/src/main/java/net/freerouting/freeroute/BoardPanel.java
+++ b/src/main/java/net/freerouting/freeroute/BoardPanel.java
@@ -22,6 +22,7 @@ package net.freerouting.freeroute;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -250,7 +251,7 @@ public class BoardPanel extends javax.swing.JPanel {
 
         Point2D center_point = new Point2D.Double(center_x, center_y);
 
-        java.awt.Rectangle display_rect = get_viewport_bounds();
+        Rectangle2D display_rect = get_viewport_bounds();
 
         double width_factor = display_rect.getWidth() / width_of_zoom_frame;
         double height_factor = display_rect.getHeight() / height_of_zoom_frame;
@@ -273,7 +274,7 @@ public class BoardPanel extends javax.swing.JPanel {
 
     public java.awt.geom.Point2D get_viewport_center() {
         java.awt.Point pos = get_viewport_position();
-        java.awt.Rectangle display_rect = get_viewport_bounds();
+        Rectangle2D display_rect = get_viewport_bounds();
         return new java.awt.geom.Point2D.Double(pos.getX() + display_rect.getCenterX(), pos.getY() + display_rect.getCenterY());
     }
 
@@ -310,7 +311,7 @@ public class BoardPanel extends javax.swing.JPanel {
     /**
      * Returns the viewport bounds of the scroll pane
      */
-    java.awt.Rectangle get_viewport_bounds() {
+    Rectangle2D get_viewport_bounds() {
         return scroll_pane.getViewportBorderBounds();
     }
 
@@ -319,7 +320,7 @@ public class BoardPanel extends javax.swing.JPanel {
      * near the border of the viewport. Returns the adjustment vector
      */
     java.awt.Point set_viewport_center(java.awt.geom.Point2D p_point) {
-        java.awt.Rectangle display_rect = get_viewport_bounds();
+        Rectangle2D display_rect = get_viewport_bounds();
         double x_corner = p_point.getX() - display_rect.getWidth() / 2;
         double y_corner = p_point.getY() - display_rect.getHeight() / 2;
         Dimension panel_size = getSize();
@@ -354,9 +355,9 @@ public class BoardPanel extends javax.swing.JPanel {
 
     private void scroll_near_border(java.awt.event.MouseEvent p_evt) {
         final int border_dist = 50;
-        java.awt.Rectangle r
-                = new java.awt.Rectangle(p_evt.getX() - border_dist, p_evt.getY() - border_dist, 2 * border_dist, 2 * border_dist);
-        ((JPanel) p_evt.getSource()).scrollRectToVisible(r);
+        Rectangle2D r
+                = new Rectangle2D.Double(p_evt.getX() - border_dist, p_evt.getY() - border_dist, 2 * border_dist, 2 * border_dist);
+        ((JPanel) p_evt.getSource()).scrollRectToVisible(r.getBounds());
     }
 
     private void scroll_middle_mouse(java.awt.event.MouseEvent p_evt) {

--- a/src/main/java/net/freerouting/freeroute/BoardSavableSubWindow.java
+++ b/src/main/java/net/freerouting/freeroute/BoardSavableSubWindow.java
@@ -21,6 +21,8 @@ package net.freerouting.freeroute;
 
 import java.io.IOException;
 
+import java.awt.geom.Rectangle2D;
+
 /**
  * Subwindow of the board frame, whose location and visibility can be saved and
  * read from disc.
@@ -36,7 +38,7 @@ public abstract class BoardSavableSubWindow extends BoardSubWindow {
     public boolean read(java.io.ObjectInputStream p_object_stream) {
         try {
             SavedAttributes saved_attributes = (SavedAttributes) p_object_stream.readObject();
-            this.setBounds(saved_attributes.bounds);
+            this.setBounds(saved_attributes.bounds.getBounds());
             this.setVisible(saved_attributes.is_visible);
             return true;
         } catch (IOException | ClassNotFoundException e) {
@@ -71,10 +73,10 @@ public abstract class BoardSavableSubWindow extends BoardSubWindow {
      */
     static private class SavedAttributes implements java.io.Serializable {
 
-        public final java.awt.Rectangle bounds;
+        public final Rectangle2D bounds;
         public final boolean is_visible;
 
-        public SavedAttributes(java.awt.Rectangle p_bounds, boolean p_is_visible) {
+        public SavedAttributes(Rectangle2D p_bounds, boolean p_is_visible) {
             bounds = p_bounds;
             is_visible = p_is_visible;
         }

--- a/src/main/java/net/freerouting/freeroute/GUIDefaultsFile.java
+++ b/src/main/java/net/freerouting/freeroute/GUIDefaultsFile.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import net.freerouting.freeroute.board.ItemSelectionFilter;
 import net.freerouting.freeroute.datastructures.IndentFileWriter;
 
+import java.awt.geom.Rectangle2D;
+
 /**
  * Description of a text file, where the board independent interactive settings
  * are stored.
@@ -260,7 +262,7 @@ public class GUIDefaultsFile {
             System.out.println("GUIDefaultsFile.read_frame_scope: bounds expected");
             return false;
         }
-        java.awt.Rectangle bounds = read_rectangle();
+        Rectangle2D bounds = read_rectangle();
         if (bounds == null) {
             return false;
         }
@@ -347,16 +349,16 @@ public class GUIDefaultsFile {
         }
         curr_frame.setVisible(is_visible);
         if (p_frame == Keyword.BOARD_FRAME) {
-            curr_frame.setBounds(bounds);
+            curr_frame.setBounds(bounds.getBounds());
         } else {
             // Set only the location.
             // Do not change the size of the frame because it depends on the layer count.
-            curr_frame.setLocation(bounds.getLocation());
+            curr_frame.setLocation(bounds.getBounds().getLocation());
         }
         return true;
     }
 
-    private java.awt.Rectangle read_rectangle() throws java.io.IOException {
+    private Rectangle2D read_rectangle() throws java.io.IOException {
         int[] coor = new int[4];
         for (int i = 0; i < 4; ++i) {
             Object next_token = this.scanner.next_token();
@@ -366,7 +368,7 @@ public class GUIDefaultsFile {
             }
             coor[i] = (Integer) next_token;
         }
-        return new java.awt.Rectangle(coor[0], coor[1], coor[2], coor[3]);
+        return new Rectangle2D.Double(coor[0], coor[1], coor[2], coor[3]);
     }
 
     private void write_frame_scope(javax.swing.JFrame p_frame, String p_frame_name)
@@ -383,7 +385,7 @@ public class GUIDefaultsFile {
         out_file.end_scope();
     }
 
-    private void write_bounds(java.awt.Rectangle p_bounds) throws java.io.IOException {
+    private void write_bounds(Rectangle2D p_bounds) throws java.io.IOException {
         out_file.start_scope();
         out_file.write("bounds");
         out_file.new_line();

--- a/src/main/java/net/freerouting/freeroute/boardgraphics/CoordinateTransform.java
+++ b/src/main/java/net/freerouting/freeroute/boardgraphics/CoordinateTransform.java
@@ -17,6 +17,7 @@ package net.freerouting.freeroute.boardgraphics;
 
 import java.awt.Dimension;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 import net.freerouting.freeroute.geometry.planar.FloatPoint;
 import net.freerouting.freeroute.geometry.planar.IntBox;
 import net.freerouting.freeroute.geometry.planar.Limits;
@@ -66,6 +67,7 @@ public class CoordinateTransform implements java.io.Serializable {
 
     /**
      * Copy constructor
+     * @param p_coordinate_transform
      */
     public CoordinateTransform(CoordinateTransform p_coordinate_transform) {
         this.screen_bounds = new Dimension(p_coordinate_transform.screen_bounds);
@@ -154,29 +156,29 @@ public class CoordinateTransform implements java.io.Serializable {
     }
 
     /**
-     * Transform a geometry.planar.IntBox to a java.awt.Rectangle If the
+     * Transform a geometry.planar.IntBox to a Rectangle2D If the
      * internal rotation is not a multiple of Pi/2, a bounding rectangle of the
      * rotated rectangular shape is returned.
      */
-    public java.awt.Rectangle board_to_screen(IntBox p_box) {
+    public Rectangle2D board_to_screen(IntBox p_box) {
         Point2D corner_1 = board_to_screen(p_box.ll.to_float());
         Point2D corner_2 = board_to_screen(p_box.ur.to_float());
         double ll_x = Math.min(corner_1.getX(), corner_2.getX());
         double ll_y = Math.min(corner_1.getY(), corner_2.getY());
         double dx = Math.abs(corner_2.getX() - corner_1.getX());
         double dy = Math.abs(corner_2.getY() - corner_1.getY());
-        java.awt.Rectangle result
-                = new java.awt.Rectangle((int) Math.floor(ll_x), (int) Math.floor(ll_y),
+        Rectangle2D result
+                = new Rectangle2D.Double((int) Math.floor(ll_x), (int) Math.floor(ll_y),
                         (int) Math.ceil(dx), (int) Math.ceil(dy));
         return result;
     }
 
     /**
-     * Transform a java.awt.Rectangle to a geometry.planar.IntBox If the
+     * Transform a Rectangle2D to a geometry.planar.IntBox If the
      * internal rotation is not a multiple of Pi/2, a bounding box of the
      * rotated rectangular shape is returned.
      */
-    public IntBox screen_to_board(java.awt.Rectangle p_rect) {
+    public IntBox screen_to_board(Rectangle2D p_rect) {
         FloatPoint corner_1 = screen_to_board(new Point2D.Double(p_rect.getX(), p_rect.getY()));
         FloatPoint corner_2 = screen_to_board(new Point2D.Double(p_rect.getX() + p_rect.getWidth(),
                 p_rect.getY() + p_rect.getHeight()));

--- a/src/main/java/net/freerouting/freeroute/boardgraphics/GraphicsContext.java
+++ b/src/main/java/net/freerouting/freeroute/boardgraphics/GraphicsContext.java
@@ -22,7 +22,6 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
-import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
@@ -153,7 +152,7 @@ public class GraphicsContext implements java.io.Serializable {
             return;
         }
         Graphics2D g2 = (Graphics2D) p_g;
-        Rectangle clip_shape = (Rectangle) p_g.getClip();
+        Rectangle2D clip_shape = (Rectangle2D) p_g.getClip();
         // the class member update_box cannot be used here, because
         // the dirty rectangle is internally enlarged by the system.
         // Therefore we can not improve the performance by using an
@@ -276,7 +275,7 @@ public class GraphicsContext implements java.io.Serializable {
         }
         Point2D center = coordinate_transform.board_to_screen(p_circle.center.to_float());
         double radius = coordinate_transform.board_to_screen(p_circle.radius);
-        if (!point_near_rectangle(center.getX(), center.getY(), (Rectangle) p_g.getClip(), radius)) {
+        if (!point_near_rectangle(center.getX(), center.getY(), (Rectangle2D) p_g.getClip(), radius)) {
             return;
         }
         double diameter = 2 * radius;
@@ -310,7 +309,7 @@ public class GraphicsContext implements java.io.Serializable {
         for (Ellipse curr_ellipse : p_ellipse_arr) {
             Point2D center = coordinate_transform.board_to_screen(curr_ellipse.center);
             double bigger_radius = coordinate_transform.board_to_screen(curr_ellipse.bigger_radius);
-            if (!point_near_rectangle(center.getX(), center.getY(), (Rectangle) p_g.getClip(), bigger_radius)) {
+            if (!point_near_rectangle(center.getX(), center.getY(), (Rectangle2D) p_g.getClip(), bigger_radius)) {
                 continue;
             }
             double smaller_radius = coordinate_transform.board_to_screen(curr_ellipse.smaller_radius);
@@ -334,17 +333,17 @@ public class GraphicsContext implements java.io.Serializable {
      * Checks, if the distance of the point with coordinates p_x, p_y to p_rect
      * ist at most p_dist.
      */
-    private boolean point_near_rectangle(double p_x, double p_y, Rectangle p_rect, double p_dist) {
-        if (p_x < p_rect.x - p_dist) {
+    private boolean point_near_rectangle(double p_x, double p_y, Rectangle2D p_rect, double p_dist) {
+        if (p_x < p_rect.getX() - p_dist) {
             return false;
         }
-        if (p_y < p_rect.y - p_dist) {
+        if (p_y < p_rect.getY() - p_dist) {
             return false;
         }
-        if (p_x > p_rect.x + p_rect.width + p_dist) {
+        if (p_x > p_rect.getX() + p_rect.getWidth() + p_dist) {
             return false;
         }
-        return p_y <= p_rect.y + p_rect.height + p_dist;
+        return p_y <= p_rect.getY() + p_rect.getHeight() + p_dist;
     }
 
     /**
@@ -408,7 +407,7 @@ public class GraphicsContext implements java.io.Serializable {
                 System.out.println("GraphicsContext.fill_area: shape not bounded");
                 return;
             }
-            Rectangle clip_shape = (Rectangle) p_g.getClip();
+            Rectangle2D clip_shape = (Rectangle2D) p_g.getClip();
             IntBox clip_box = coordinate_transform.screen_to_board(clip_shape);
             if (!border.bounding_box().intersects(clip_box)) {
                 return;
@@ -599,7 +598,7 @@ public class GraphicsContext implements java.io.Serializable {
     /**
      * Returns the bounding box of the design in screen coordinates.
      */
-    public java.awt.Rectangle get_design_bounds() {
+    public Rectangle2D get_design_bounds() {
         return coordinate_transform.board_to_screen(coordinate_transform.design_box);
     }
 

--- a/src/main/java/net/freerouting/freeroute/interactive/BoardHandling.java
+++ b/src/main/java/net/freerouting/freeroute/interactive/BoardHandling.java
@@ -22,7 +22,7 @@ package net.freerouting.freeroute.interactive;
 
 import java.awt.Dimension;
 import java.awt.Graphics;
-import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
 import java.awt.geom.Point2D;
 import java.io.File;
 import java.io.IOException;
@@ -631,8 +631,8 @@ public class BoardHandling {
      */
     public void repaint() {
         if (this.paint_immediately) {
-            final Rectangle MAX_RECTAMGLE = new Rectangle(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
-            panel.paintImmediately(MAX_RECTAMGLE);
+            final Rectangle2D MAX_RECTAMGLE = new Rectangle2D.Double(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+            panel.paintImmediately(MAX_RECTAMGLE.getBounds());
         } else {
             panel.repaint();
         }
@@ -641,11 +641,11 @@ public class BoardHandling {
     /**
      * Repaints a rectangle of board panel on the screen.
      */
-    public void repaint(Rectangle p_rect) {
+    public void repaint(Rectangle2D p_rect) {
         if (this.paint_immediately) {
-            panel.paintImmediately(p_rect);
+            panel.paintImmediately(p_rect.getBounds());
         } else {
-            panel.repaint(p_rect);
+            panel.repaint(p_rect.getBounds());
         }
     }
 
@@ -1468,11 +1468,11 @@ public class BoardHandling {
      * Gets a surrounding rectangle of the area, where an update of the graphics
      * is needed caused by the previous interactive actions.
      */
-    Rectangle get_graphics_update_rectangle() {
-        Rectangle result;
+    Rectangle2D get_graphics_update_rectangle() {
+        Rectangle2D result;
         IntBox update_box = board.get_graphics_update_box();
         if (update_box == null || update_box.is_empty()) {
-            result = new Rectangle(0, 0, 0, 0);
+            result = new Rectangle2D.Double(0, 0, 0, 0);
         } else {
             IntBox offset_box = update_box.offset(board.get_max_trace_half_width());
             result = graphics_context.coordinate_transform.board_to_screen(offset_box);


### PR DESCRIPTION
Hi,

on my MacBook with MacOSX El Captian and Java 1.8.0_101 Freerouting failed with some "java.lang.classcastexception java.awt.geom.rectangle2d$double cannot be cast to java.awt.rectangle" messages and didn't show the routing part of the program window at all. Hence I had a look at cchamilt's fork changes and adapted it to this fork, as it seems to be the most recent one for me.

For me freerouting is now working as expected and I think these changes might also be useful for other platforms with recent Java version.

Best regards,
Thomas
