### PR TITLE
Fixed failure to load files containing Ω, μ, etc.

### DIFF
--- a/src/main/jflex/net/freerouting/freeroute/designformats/specctra/SpecctraFileDescription.flex
+++ b/src/main/jflex/net/freerouting/freeroute/designformats/specctra/SpecctraFileDescription.flex
@@ -38,7 +38,7 @@ SpecCharANSI2 = [¡-ÿ]
 SpecCharANSI = {SpecCharANSI1}|{SpecCharANSI2}
 
 
-SpecChar1 = {SpecCharASCII}|{SpecCharANSI}
+SpecChar1 = {SpecCharASCII}|{SpecCharANSI}|μ|Ω|θ|α|ε|π|σ|φ
 
 SpecChar2 = {SpecChar1}|-|\+
 


### PR DESCRIPTION
If you had, say, a capacitor with a value in μF, the file wouldn't load and no feedback would be given. This makes the file load correctly. Tested against export/imports from KiCAD.