### PR TITLE
Use System.arrayCopy and Collections.add whenever possible.

### DIFF
--- a/src/main/java/net/freerouting/freeroute/WindowVia.java
+++ b/src/main/java/net/freerouting/freeroute/WindowVia.java
@@ -435,9 +435,7 @@ public final class WindowVia extends BoardSavableSubWindow {
                 return;
             }
             List<WindowObjectInfo.Printable> object_list = new LinkedList<>();
-            for (ViaRule selected_object : selected_objects) {
-                object_list.add(selected_object);
-            }
+            object_list.addAll(selected_objects);
             net.freerouting.freeroute.board.CoordinateTransform coordinate_transform = board_frame.board_panel.board_handling.coordinate_transform;
             WindowObjectInfo new_window
                     = WindowObjectInfo.display(resources.getString("selected_rule"), object_list, board_frame, coordinate_transform);

--- a/src/main/java/net/freerouting/freeroute/autoroute/InsertFoundConnectionAlgo.java
+++ b/src/main/java/net/freerouting/freeroute/autoroute/InsertFoundConnectionAlgo.java
@@ -138,9 +138,7 @@ public class InsertFoundConnectionAlgo {
         int from_corner_no = 0;
         for (int i = 1; i < p_trace.corners.length; ++i) {
             Point[] curr_corner_arr = new Point[i - from_corner_no + 1];
-            for (int j = from_corner_no; j <= i; ++j) {
-                curr_corner_arr[j - from_corner_no] = p_trace.corners[j];
-            }
+            System.arraycopy(p_trace.corners, from_corner_no, curr_corner_arr, 0, i + 1 - from_corner_no);
             Polyline insert_polyline = new Polyline(curr_corner_arr);
             Point ok_point = board.insert_forced_trace_polyline(insert_polyline,
                     ctrl.trace_half_width[p_trace.layer], p_trace.layer, net_no_arr, ctrl.trace_clearance_class_no,

--- a/src/main/java/net/freerouting/freeroute/board/PullTightAlgo45.java
+++ b/src/main/java/net/freerouting/freeroute/board/PullTightAlgo45.java
@@ -209,9 +209,7 @@ class PullTightAlgo45 extends PullTightAlgo {
             return p_polyline;
         }
         Point adjusted_corners[] = new Point[new_corner_count + 2];
-        for (int i = 0; i < new_corner_count; ++i) {
-            adjusted_corners[i] = new_corners[i];
-        }
+        System.arraycopy(new_corners, 0, adjusted_corners, 0, new_corner_count);
         adjusted_corners[new_corner_count] = curr_corner[1];
         adjusted_corners[new_corner_count + 1] = curr_corner[2];
         Polyline result = new Polyline(adjusted_corners);
@@ -539,26 +537,20 @@ class PullTightAlgo45 extends PullTightAlgo {
                 Line[] new_lines = new Line[trace_polyline.arr.length + 1];
                 new_lines[0] = other_trace_line;
                 new_lines[1] = add_line;
-                for (int i = 2; i < new_lines.length; ++i) {
-                    new_lines[i] = trace_polyline.arr[i - 1];
-                }
+                System.arraycopy(trace_polyline.arr, 1, new_lines, 2, new_lines.length - 2);
                 return new Polyline(new_lines);
             }
         } else if (bend) {
             Line[] check_line_arr = new Line[trace_polyline.arr.length + 1];
             check_line_arr[0] = other_prev_trace_line;
             check_line_arr[1] = other_trace_line;
-            for (int i = 2; i < check_line_arr.length; ++i) {
-                check_line_arr[i] = trace_polyline.arr[i - 1];
-            }
+            System.arraycopy(trace_polyline.arr, 1, check_line_arr, 2, check_line_arr.length - 2);
             Line new_line = reposition_line(check_line_arr, 2);
             if (new_line != null) {
                 Line[] new_lines = new Line[trace_polyline.arr.length];
                 new_lines[0] = other_trace_line;
                 new_lines[1] = new_line;
-                for (int i = 2; i < new_lines.length; ++i) {
-                    new_lines[i] = trace_polyline.arr[i];
-                }
+                System.arraycopy(trace_polyline.arr, 2, new_lines, 2, new_lines.length - 2);
                 return new Polyline(new_lines);
             }
         }
@@ -648,26 +640,20 @@ class PullTightAlgo45 extends PullTightAlgo {
                 Line add_line = translate_line.translate(translate_dist);
                 // constract the new trace polyline.
                 Line[] new_lines = new Line[trace_polyline.arr.length + 1];
-                for (int i = 0; i < trace_polyline.arr.length - 1; ++i) {
-                    new_lines[i] = trace_polyline.arr[i];
-                }
+                System.arraycopy(trace_polyline.arr, 0, new_lines, 0, trace_polyline.arr.length - 1);
                 new_lines[new_lines.length - 2] = add_line;
                 new_lines[new_lines.length - 1] = other_trace_line;
                 return new Polyline(new_lines);
             }
         } else if (bend) {
             Line[] check_line_arr = new Line[trace_polyline.arr.length + 1];
-            for (int i = 0; i < trace_polyline.arr.length - 1; ++i) {
-                check_line_arr[i] = trace_polyline.arr[i];
-            }
+            System.arraycopy(trace_polyline.arr, 0, check_line_arr, 0, trace_polyline.arr.length - 1);
             check_line_arr[check_line_arr.length - 2] = other_trace_line;
             check_line_arr[check_line_arr.length - 1] = other_prev_trace_line;
             Line new_line = reposition_line(check_line_arr, trace_polyline.arr.length - 2);
             if (new_line != null) {
                 Line[] new_lines = new Line[trace_polyline.arr.length];
-                for (int i = 0; i < new_lines.length - 2; ++i) {
-                    new_lines[i] = trace_polyline.arr[i];
-                }
+                System.arraycopy(trace_polyline.arr, 0, new_lines, 0, new_lines.length - 2);
                 new_lines[new_lines.length - 2] = new_line;
                 new_lines[new_lines.length - 1] = other_trace_line;
                 return new Polyline(new_lines);

--- a/src/main/java/net/freerouting/freeroute/board/PullTightAlgo90.java
+++ b/src/main/java/net/freerouting/freeroute/board/PullTightAlgo90.java
@@ -86,9 +86,7 @@ class PullTightAlgo90 extends PullTightAlgo {
         Line[] new_lines = new Line[p_polyline.arr.length - 1];
         new_lines[0] = p_polyline.arr[1];
         new_lines[1] = p_polyline.arr[0];
-        for (int i = 2; i < new_lines.length; ++i) {
-            new_lines[i] = p_polyline.arr[i + 1];
-        }
+        System.arraycopy(p_polyline.arr, 3, new_lines, 2, new_lines.length - 2);
         return new Polyline(new_lines);
     }
 

--- a/src/main/java/net/freerouting/freeroute/board/PullTightAlgoAnyAngle.java
+++ b/src/main/java/net/freerouting/freeroute/board/PullTightAlgoAnyAngle.java
@@ -871,26 +871,20 @@ class PullTightAlgoAnyAngle extends PullTightAlgo {
                 Line[] new_lines = new Line[new_line_count];
                 new_lines[0] = other_trace_line;
                 new_lines[1] = add_line;
-                for (int i = 2; i < new_lines.length; ++i) {
-                    new_lines[i] = trace_polyline.arr[i - diff];
-                }
+                System.arraycopy(trace_polyline.arr, 2 - diff, new_lines, 2, new_lines.length - 2);
                 return new Polyline(new_lines);
             }
         } else if (bend) {
             Line[] check_line_arr = new Line[new_line_count];
             check_line_arr[0] = other_prev_trace_line;
             check_line_arr[1] = other_trace_line;
-            for (int i = 2; i < check_line_arr.length; ++i) {
-                check_line_arr[i] = trace_polyline.arr[i - diff];
-            }
+            System.arraycopy(trace_polyline.arr, 2 - diff, check_line_arr, 2, check_line_arr.length - 2);
             Line new_line = reposition_line(check_line_arr, 0);
             if (new_line != null) {
                 Line[] new_lines = new Line[trace_polyline.arr.length];
                 new_lines[0] = other_trace_line;
                 new_lines[1] = new_line;
-                for (int i = 2; i < new_lines.length; ++i) {
-                    new_lines[i] = trace_polyline.arr[i];
-                }
+                System.arraycopy(trace_polyline.arr, 2, new_lines, 2, new_lines.length - 2);
                 return new Polyline(new_lines);
             }
         }
@@ -997,26 +991,20 @@ class PullTightAlgoAnyAngle extends PullTightAlgo {
                 Line add_line = translate_line.translate(translate_dist);
                 // constract the new trace polyline.
                 Line[] new_lines = new Line[new_line_count];
-                for (int i = 0; i < trace_polyline.arr.length - 1; ++i) {
-                    new_lines[i] = trace_polyline.arr[i];
-                }
+                System.arraycopy(trace_polyline.arr, 0, new_lines, 0, trace_polyline.arr.length - 1);
                 new_lines[new_lines.length - 2] = add_line;
                 new_lines[new_lines.length - 1] = other_trace_line;
                 return new Polyline(new_lines);
             }
         } else if (bend) {
             Line[] check_line_arr = new Line[new_line_count];
-            for (int i = 0; i < check_line_arr.length - 2; ++i) {
-                check_line_arr[i] = trace_polyline.arr[i + diff];
-            }
+            System.arraycopy(trace_polyline.arr, diff, check_line_arr, 0, check_line_arr.length - 2);
             check_line_arr[check_line_arr.length - 2] = other_trace_line;
             check_line_arr[check_line_arr.length - 1] = other_prev_trace_line;
             Line new_line = reposition_line(check_line_arr, check_line_arr.length - 5);
             if (new_line != null) {
                 Line[] new_lines = new Line[trace_polyline.arr.length];
-                for (int i = 0; i < new_lines.length - 2; ++i) {
-                    new_lines[i] = trace_polyline.arr[i];
-                }
+                System.arraycopy(trace_polyline.arr, 0, new_lines, 0, new_lines.length - 2);
                 new_lines[new_lines.length - 2] = new_line;
                 new_lines[new_lines.length - 1] = other_trace_line;
                 return new Polyline(new_lines);

--- a/src/main/java/net/freerouting/freeroute/board/ShapeSearchTree.java
+++ b/src/main/java/net/freerouting/freeroute/board/ShapeSearchTree.java
@@ -136,9 +136,7 @@ public class ShapeSearchTree extends net.freerouting.freeroute.datastructures.Mi
         }
 
         // correct the precalculated tree shapes first, because it is used in this.insert
-        for (int i = p_keep_at_start_count; i < new_shape_count - p_keep_at_end_count; ++i) {
-            new_precalculated_tree_shapes[i] = changed_shapes[i - p_keep_at_start_count];
-        }
+        System.arraycopy(changed_shapes, 0, new_precalculated_tree_shapes, p_keep_at_start_count, new_shape_count - p_keep_at_end_count - p_keep_at_start_count);
         p_obj.set_precalculated_tree_shapes(new_precalculated_tree_shapes, this);
 
         for (int i = p_keep_at_start_count; i < new_shape_count - p_keep_at_end_count; ++i) {
@@ -868,9 +866,7 @@ public class ShapeSearchTree extends net.freerouting.freeroute.datastructures.Mi
             int offset_width = this.clearance_compensation_value(p_obstacle_area.clearance_class_no(), p_obstacle_area.get_layer_no());
             curr_convex_shape = (TileShape) curr_convex_shape.enlarge(offset_width);
             TileShape[] curr_tree_shapes = curr_convex_shape.divide_into_sections(max_tree_shape_width);
-            for (int j = 0; j < curr_tree_shapes.length; ++j) {
-                tree_shape_list.add(curr_tree_shapes[j]);
-            }
+            Collections.addAll(tree_shape_list, curr_tree_shapes);
         }
         return tree_shape_list.stream().toArray(TileShape[]::new);
     }

--- a/src/main/java/net/freerouting/freeroute/board/ShapeSearchTree.java
+++ b/src/main/java/net/freerouting/freeroute/board/ShapeSearchTree.java
@@ -20,6 +20,7 @@
 package net.freerouting.freeroute.board;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.NoSuchElementException;

--- a/src/main/java/net/freerouting/freeroute/board/Trace.java
+++ b/src/main/java/net/freerouting/freeroute/board/Trace.java
@@ -321,12 +321,10 @@ public abstract class Trace extends Item implements Connectable {
         Collection<Item> start_contacts = this.get_start_contacts();
         // a cycle exists if through expanding the start contact we reach
         // this trace again via an end contact
-        for (Item curr_contact : start_contacts) {
-            // make shure, that all direct neighbours are
-            // expanded from here, to block coming back to
-            // this trace via a start contact.
-            visited_items.add(curr_contact);
-        }
+        // make shure, that all direct neighbours are
+        // expanded from here, to block coming back to
+        // this trace via a start contact.
+        visited_items.addAll(start_contacts);
         boolean ignore_areas = false;
         if (this.net_no_arr.length > 0) {
             net.freerouting.freeroute.rules.Net curr_net = this.board.rules.nets.get(this.net_no_arr[0]);

--- a/src/main/java/net/freerouting/freeroute/designformats/specctra/Net.java
+++ b/src/main/java/net/freerouting/freeroute/designformats/specctra/Net.java
@@ -96,9 +96,7 @@ class Net {
 
     void set_pins(Collection<Pin> p_pin_list) {
         pin_list = new TreeSet<>();
-        for (Pin curr_pin : p_pin_list) {
-            pin_list.add(curr_pin);
-        }
+        pin_list.addAll(p_pin_list);
     }
 
     Set<Pin> get_pins() {

--- a/src/main/java/net/freerouting/freeroute/designformats/specctra/SessionFile.java
+++ b/src/main/java/net/freerouting/freeroute/designformats/specctra/SessionFile.java
@@ -331,9 +331,7 @@ public class SessionFile {
         }
         if (corner_index < coors.length) {
             int[] adjusted_coors = new int[corner_index];
-            for (int i = 0; i < adjusted_coors.length; ++i) {
-                adjusted_coors[i] = coors[i];
-            }
+            System.arraycopy(coors, 0, adjusted_coors, 0, adjusted_coors.length);
             coors = adjusted_coors;
         }
         write_path(board_layer.get_name(), wire_width, coors, p_identifier_type, p_file);

--- a/src/main/java/net/freerouting/freeroute/geometry/planar/IntOctagon.java
+++ b/src/main/java/net/freerouting/freeroute/geometry/planar/IntOctagon.java
@@ -1267,9 +1267,7 @@ public class IntOctagon extends RegularTileShape {
         }
 
         // add the 4 octagons to the result
-        for (int i = 0; i < 4; ++i) {
-            result[4 + i] = octagons[i];
-        }
+        System.arraycopy(octagons, 0, result, 4, 4);
         return result;
     }
 

--- a/src/main/java/net/freerouting/freeroute/geometry/planar/PolygonShape.java
+++ b/src/main/java/net/freerouting/freeroute/geometry/planar/PolygonShape.java
@@ -345,12 +345,8 @@ public class PolygonShape extends PolylineShape {
             if (next_point.side_of(prev_point, curr_point) != Side.ON_THE_LEFT) {
                 //skip curr_point;
                 Point[] new_corners = new Point[corners.length - 1];
-                for (int i = 0; i < ind; ++i) {
-                    new_corners[i] = corners[i];
-                }
-                for (int i = ind; i < new_corners.length; ++i) {
-                    new_corners[i] = corners[i + 1];
-                }
+                System.arraycopy(corners, 0, new_corners, 0, ind);
+                System.arraycopy(corners, ind + 1, new_corners, ind, new_corners.length - ind);
                 PolygonShape result = new PolygonShape(new_corners);
                 return result.convex_hull();
             }

--- a/src/main/java/net/freerouting/freeroute/geometry/planar/Polyline.java
+++ b/src/main/java/net/freerouting/freeroute/geometry/planar/Polyline.java
@@ -795,24 +795,16 @@ public class Polyline implements java.io.Serializable {
                 }
             } else {
                 // skip the last line of p_other
-                for (int i = 0; i < p_other.arr.length - 1; ++i) {
-                    line_arr[i] = p_other.arr[i];
-                }
+                System.arraycopy(p_other.arr, 0, line_arr, 0, p_other.arr.length - 1);
             }
             // append the lines of this polyline, skip the first line
-            for (int i = 1; i < arr.length; ++i) {
-                line_arr[p_other.arr.length + i - 2] = arr[i];
-            }
+            System.arraycopy(arr, 1, line_arr, p_other.arr.length + 1 - 2, arr.length - 1);
         } else {
             // insert the lines of this polyline in front, skip the last line
-            for (int i = 0; i < arr.length - 1; ++i) {
-                line_arr[i] = arr[i];
-            }
+            System.arraycopy(arr, 0, line_arr, 0, arr.length - 1);
             if (combine_other_at_start) {
                 // skip the first line of p_other
-                for (int i = 1; i < p_other.arr.length; ++i) {
-                    line_arr[arr.length + i - 2] = p_other.arr[i];
-                }
+                System.arraycopy(p_other.arr, 1, line_arr, arr.length + 1 - 2, p_other.arr.length - 1);
             } else {
                 // insert in reverse order, skip the last line of p_other
                 for (int i = 1; i < p_other.arr.length; ++i) {

--- a/src/main/java/net/freerouting/freeroute/geometry/planar/TileShape.java
+++ b/src/main/java/net/freerouting/freeroute/geometry/planar/TileShape.java
@@ -713,9 +713,7 @@ public abstract class TileShape extends PolylineShape implements ConvexShape {
         }
         int[][] normalized_result = new int[intersection_count][2];
         for (int j = 0; j < intersection_count; ++j) {
-            for (int i = 0; i < 2; ++i) {
-                normalized_result[j][i] = result[j][i];
-            }
+            System.arraycopy(result[j], 0, normalized_result[j], 0, 2);
         }
         return normalized_result;
     }

--- a/src/main/java/net/freerouting/freeroute/rules/ClearanceMatrix.java
+++ b/src/main/java/net/freerouting/freeroute/rules/ClearanceMatrix.java
@@ -255,9 +255,7 @@ public class ClearanceMatrix implements java.io.Serializable {
             new_row[i] = new Row(curr_old_row.name);
             Row curr_new_row = new_row[i];
             curr_new_row.max_value = curr_old_row.max_value;
-            for (int j = 0; j < old_class_count; ++j) {
-                curr_new_row.column[j] = curr_old_row.column[j];
-            }
+            System.arraycopy(curr_old_row.column, 0, curr_new_row.column, 0, old_class_count);
 
             curr_new_row.column[old_class_count] = new MatrixEntry();
         }


### PR DESCRIPTION
There were quite a few manual array/collection copy operations scattered throughout the code.  This patch removes said manual copy operations and forces the usage of System.arrayCopy and Collections.add to speed said operations up a bit and clarifying the code up at the same time.